### PR TITLE
add missing include

### DIFF
--- a/include/multi_index/detail/no_duplicate_tags.hpp
+++ b/include/multi_index/detail/no_duplicate_tags.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <brigand/algorithms/find.hpp>
 #include <brigand/algorithms/transform.hpp>
 #include <brigand/functions/if.hpp>
 #include <brigand/functions/logical/not.hpp>


### PR DESCRIPTION
brigand::find was  certainly included transitively in older versions of brigand but this is not the case anymore